### PR TITLE
Fixed a bug related HMAC, that requires bytes as the first parameter …

### DIFF
--- a/mercadobitcoin/trade_api.py
+++ b/mercadobitcoin/trade_api.py
@@ -124,9 +124,8 @@ class TradeApi(Base):
 
 
     def __post_tapi(self, method, params={}):
-        payload = { "tapi_method": method, "tapi_nonce": str(int(time.time())) }
+        payload = { "tapi_method": method, "tapi_nonce": str(int(time.time()) * 1000) }
         payload.update(params)
-
         headers = {
             "Content-Type": "application/x-www-form-urlencoded",
             "TAPI-ID": self.id,
@@ -138,7 +137,7 @@ class TradeApi(Base):
 
 
     def __signature(self, payload):
-        signature = hmac.new(self.secret, digestmod=hashlib.sha512)
+        signature = hmac.new(self.secret.encode('utf-8'), digestmod=hashlib.sha512)
         params = self.path + '?' + urlencode(payload)
         signature.update(params.encode('utf-8'))
         return signature.hexdigest()

--- a/mercadobitcoin/trade_api.py
+++ b/mercadobitcoin/trade_api.py
@@ -124,7 +124,7 @@ class TradeApi(Base):
 
 
     def __post_tapi(self, method, params={}):
-        payload = { "tapi_method": method, "tapi_nonce": str(int(time.time()) * 1000) }
+        payload = { "tapi_method": method, "tapi_nonce": str(int(time.time() * 1000)) }
         payload.update(params)
         headers = {
             "Content-Type": "application/x-www-form-urlencoded",


### PR DESCRIPTION
HMAC requisita que o primeiro parâmetro seja um array de bytes e também converti o parâmetro TAPI_NONCE para milisegundos, sendo assim evita que outros apps que usam a API travam o uso por usarem o tapi_nonce maior.