### PR TITLE
Use bigger tapi_nonce

### DIFF
--- a/mercadobitcoin/trade_api.py
+++ b/mercadobitcoin/trade_api.py
@@ -124,7 +124,7 @@ class TradeApi(Base):
 
 
     def __post_tapi(self, method, params={}):
-        payload = { "tapi_method": method, "tapi_nonce": str(int(time.time())) }
+        payload = { "tapi_method": method, "tapi_nonce": str(int(time.time()*1000000))}
         payload.update(params)
 
         headers = {


### PR DESCRIPTION
Set bigger tapi_nonce for more precision and almost simultaneous requests to API. Without this, request were limited to 1 per second.