### PR TITLE
Add missing tokens

### DIFF
--- a/mercadobitcoin/api.py
+++ b/mercadobitcoin/api.py
@@ -28,8 +28,8 @@ class Api(Base):
         self.available_coins = [
             "ASRFT", "ATMFT", "BCH", "BTC", "CAIFT", "CHZ", "ETH", "GALFT",
             "IMOB01", "JUVFT", "LINK", "LTC", "MBCONS01", "MBCONS02", "MBFP01",
-            "MBPRK01", "MBPRK02", "MBPRK03", "MBPRK04", "MBVASCO01", "PAXG",
-            "PSGFT", "USDC", "WBX", "XRP"
+            "MBPRK01", "MBPRK02", "MBPRK03", "MBPRK04", "MBVASCO01", "MCO2",
+            "PAXG", "PSGFT", "USDC", "WBX", "XRP"
         ]
         self.available_methods = [
             "ticker", "orderbook", "trades", "day-summary"

--- a/mercadobitcoin/api.py
+++ b/mercadobitcoin/api.py
@@ -26,10 +26,11 @@ class Api(Base):
 
     def __init__(self):
         self.available_coins = [
-            "ASRFT", "ATMFT", "BCH", "BTC", "CAIFT", "CHZ", "ETH", "GALFT",
-            "IMOB01", "JUVFT", "LINK", "LTC", "MBCONS01", "MBCONS02", "MBFP01",
-            "MBPRK01", "MBPRK02", "MBPRK03", "MBPRK04", "MBVASCO01", "MCO2",
-            "PAXG", "PSGFT", "USDC", "WBX", "XRP"
+            "ACMFT", "ACORDO01", "ASRFT", "ATMFT", "BCH", "BTC", "CAIFT",
+            "CHZ", "ETH", "GALFT", "IMOB01", "JUVFT", "LINK", "LTC",
+            "MBCONS01", "MBCONS02", "MBFP01", "MBFP02", "MBPRK01", "MBPRK02",
+            "MBPRK03", "MBPRK04", "MBVASCO01", "MCO2", "OGFT", "PAXG", "PSGFT",
+            "USDC", "WBX", "XRP"
         ]
         self.available_methods = [
             "ticker", "orderbook", "trades", "day-summary"

--- a/mercadobitcoin/trade_api.py
+++ b/mercadobitcoin/trade_api.py
@@ -20,11 +20,12 @@ class TradeApi(Base):
         self.path = "/tapi/v3/"
         self.withdrawable_coins = ["BRL", "BCH", "BTC", "ETH", "LTC", "XRP"]
         self.available_pairs = [
-            "BRLASRFT", "BRLATMFT", "BRLBCH", "BRLBTC", "BRLCAIFT", "BRLCHZ",
-            "BRLETH", "BRLGALFT", "BRLIMOB01", "BRLJUVFT", "BRLLINK", "BRLLTC",
-            "BRLMBCONS01", "BRLMBCONS02", "BRLMBFP01", "BRLMBPRK01",
-            "BRLMBPRK02", "BRLMBPRK03", "BRLMBPRK04", "BRLMBVASCO01",
-            "BRLMCO2", "BRLPAXG", "BRLPSGFT", "BRLUSDC", "BRLWBX", "BRLXRP"
+            "BRLACMFT", "BRLACORDO01", "BRLASRFT", "BRLATMFT", "BRLBCH",
+            "BRLBTC", "BRLCAIFT", "BRLCHZ", "BRLETH", "BRLGALFT", "BRLIMOB01",
+            "BRLJUVFT", "BRLLINK", "BRLLTC", "BRLMBCONS01", "BRLMBCONS02",
+            "BRLMBFP01", "BRLMBFP02", "BRLMBPRK01", "BRLMBPRK02", "BRLMBPRK03",
+            "BRLMBPRK04", "BRLMBVASCO01", "BRLMCO2", "BRLOGFT", "BRLPAXG",
+            "BRLPSGFT", "BRLUSDC", "BRLWBX", "BRLXRP"
         ]
         Base.__init__(self)
 

--- a/mercadobitcoin/trade_api.py
+++ b/mercadobitcoin/trade_api.py
@@ -24,7 +24,7 @@ class TradeApi(Base):
             "BRLETH", "BRLGALFT", "BRLIMOB01", "BRLJUVFT", "BRLLINK", "BRLLTC",
             "BRLMBCONS01", "BRLMBCONS02", "BRLMBFP01", "BRLMBPRK01",
             "BRLMBPRK02", "BRLMBPRK03", "BRLMBPRK04", "BRLMBVASCO01",
-            "BRLPAXG", "BRLPSGFT", "BRLUSDC", "BRLWBX", "BRLXRP"
+            "BRLMCO2", "BRLPAXG", "BRLPSGFT", "BRLUSDC", "BRLWBX", "BRLXRP"
         ]
         Base.__init__(self)
 
@@ -58,7 +58,7 @@ class TradeApi(Base):
 
     def list_orderbook(self, **kwargs):
         """https://www.mercadobitcoin.com.br/trade-api/#list_orderbook"""
-        
+
         check_args(kwargs, { "coin_pair": self.available_pairs }, { "full": [True, False] })
         return self.__check_response(self.__post_tapi("list_orderbook", kwargs ))
 
@@ -123,7 +123,7 @@ class TradeApi(Base):
         """https://www.mercadobitcoin.com.br/trade-api/#withdraw_coin"""
 
         check_args(kwargs, { "coin": ["XRP"], "quantity": str, "address": str, "tx_fee": str, "destination_tag": int }, { "description": str })
-        return self.__check_response(self.__post_tapi("withdraw_coin", kwargs ))        
+        return self.__check_response(self.__post_tapi("withdraw_coin", kwargs ))
 
 
     def __check_response(self, response):

--- a/tests/cassettes/tests_trade_api/test_get_account_info.yml
+++ b/tests/cassettes/tests_trade_api/test_get_account_info.yml
@@ -45,6 +45,7 @@ interactions:
         0}, "mbprk03": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
         0}, "mbprk04": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
         0}, "mbvasco01": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
+        0}, "mco2": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
         0}, "paxg": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
         0}, "psgft": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
         0}, "usdc": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":

--- a/tests/cassettes/tests_trade_api/test_get_account_info.yml
+++ b/tests/cassettes/tests_trade_api/test_get_account_info.yml
@@ -29,6 +29,8 @@ interactions:
         0}, "bch": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
         0}, "xrp": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
         0}, "eth": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
+        0}, "acmft": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
+        0}, "acordo01": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
         0}, "asrft": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
         0}, "atmft": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
         0}, "caift": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
@@ -40,12 +42,14 @@ interactions:
         0}, "mbcons01": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
         0}, "mbcons02": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
         0}, "mbfp01": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
+        0}, "mbfp02": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
         0}, "mbprk01": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
         0}, "mbprk02": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
         0}, "mbprk03": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
         0}, "mbprk04": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
         0}, "mbvasco01": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
         0}, "mco2": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
+        0}, "ogft": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
         0}, "paxg": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
         0}, "psgft": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":
         0}, "usdc": {"available": "0.00000000", "total": "0.00000000", "amount_open_orders":

--- a/tests/tests_trade_api.py
+++ b/tests/tests_trade_api.py
@@ -41,7 +41,7 @@ class TradeApiTestCase(unittest.TestCase):
                            "atmft", "caift", "chz", "galft", "imob01", "juvft",
                            "link", "mbcons01", "mbcons02", "mbfp01", "mbprk01",
                            "mbprk02", "mbprk03", "mbprk04", "mbvasco01",
-                           "paxg", "psgft", "usdc", "wbx"}
+                           "mco2", "paxg", "psgft", "usdc", "wbx"}
         for coin in tradeable_coins:
             assert coin in response["balance"]
 

--- a/tests/tests_trade_api.py
+++ b/tests/tests_trade_api.py
@@ -37,18 +37,22 @@ class TradeApiTestCase(unittest.TestCase):
     def test_get_account_info(self):
         response = self.api.get_account_info()
         assert "balance" in response
-        tradeable_coins = {"brl", "btc", "ltc", "bch", "xrp", "eth", "asrft",
-                           "atmft", "caift", "chz", "galft", "imob01", "juvft",
-                           "link", "mbcons01", "mbcons02", "mbfp01", "mbprk01",
-                           "mbprk02", "mbprk03", "mbprk04", "mbvasco01",
-                           "mco2", "paxg", "psgft", "usdc", "wbx"}
+        tradeable_coins = {"acmft", "acordo01", "asrft", "atmft", "bch", "brl",
+            "btc", "caift", "chz", "eth", "galft", "imob01", "juvft", "link",
+            "ltc", "mbcons01", "mbcons02", "mbfp01", "mbfp02", "mbprk01",
+            "mbprk02", "mbprk03", "mbprk04", "mbvasco01", "mco2", "ogft",
+            "paxg", "psgft", "usdc", "wbx", "xrp"}
         for coin in tradeable_coins:
             assert coin in response["balance"]
+        for coin in response["balance"]:
+            assert coin in tradeable_coins
 
         assert "withdrawal_limits" in response
         withdrawable_coins = {"brl", "btc", "ltc", "bch", "xrp", "eth"}
         for coin in withdrawable_coins:
             assert coin in response["withdrawal_limits"]
+        for coin in response["withdrawal_limits"]:
+            assert coin in withdrawable_coins
 
 
     @tests.vcr.use_cassette


### PR DESCRIPTION
Mercado Bitcoin now supports the following additional tokens: `ACMFT`, `ACORDO01`, `MBFP02`, `MCO2` and `OGFT`.
Add support for them.